### PR TITLE
Fix/macos build fixes

### DIFF
--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -81,7 +81,7 @@ endif()
 find_package(Protobuf CONFIG REQUIRED)
 
 if(NOT DEFINED PROTOC_EXECUTABLE)
-    set(PROTOC_EXECUTABLE "${THIRDPARTY_BUILD_DIR}/protobuf/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}")
+    set(PROTOC_EXECUTABLE "${THIRDPARTY_BUILD_DIR}/protobuf_host/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}")
 endif()
 
 set(Protobuf_PROTOC_EXECUTABLE ${PROTOC_EXECUTABLE} CACHE PATH "Initial cache" FORCE)
@@ -421,6 +421,11 @@ find_package(ProofSystem CONFIG REQUIRED)
 find_package(SGProcessingManager CONFIG REQUIRED)
 find_package(SuperGenius CONFIG REQUIRED)
 include_directories(${SuperGenius_INCLUDE_DIR})
+
+# Alias: SuperGenius exports sgns::sgns_genius_account but GeniusSDK src links against sgns::sgns_account
+if(TARGET sgns::sgns_genius_account AND NOT TARGET sgns::sgns_account)
+    add_library(sgns::sgns_account ALIAS sgns::sgns_genius_account)
+endif()
 include_directories("${ZKLLVM_BUILD_DIR}/zkLLVM/include")
 
 include_directories(

--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -81,7 +81,7 @@ endif()
 find_package(Protobuf CONFIG REQUIRED)
 
 if(NOT DEFINED PROTOC_EXECUTABLE)
-    set(PROTOC_EXECUTABLE "${THIRDPARTY_BUILD_DIR}/protobuf_host/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}")
+    set(PROTOC_EXECUTABLE "${THIRDPARTY_BUILD_DIR}/protobuf/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}")
 endif()
 
 set(Protobuf_PROTOC_EXECUTABLE ${PROTOC_EXECUTABLE} CACHE PATH "Initial cache" FORCE)
@@ -421,11 +421,6 @@ find_package(ProofSystem CONFIG REQUIRED)
 find_package(SGProcessingManager CONFIG REQUIRED)
 find_package(SuperGenius CONFIG REQUIRED)
 include_directories(${SuperGenius_INCLUDE_DIR})
-
-# Alias: SuperGenius exports sgns::sgns_genius_account but GeniusSDK src links against sgns::sgns_account
-if(TARGET sgns::sgns_genius_account AND NOT TARGET sgns::sgns_account)
-    add_library(sgns::sgns_account ALIAS sgns::sgns_genius_account)
-endif()
 include_directories("${ZKLLVM_BUILD_DIR}/zkLLVM/include")
 
 include_directories(

--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -294,8 +294,8 @@ set(gnus_upnp_LIBRARY_DIR "${THIRDPARTY_BUILD_DIR}/gnus_upnp/lib")
 set(gnus_upnp_DIR "${THIRDPARTY_BUILD_DIR}/gnus_upnp/lib/cmake/gnus_upnp")
 find_package(gnus_upnp CONFIG REQUIRED)
 
-set(zlib_DIR "${THIRDPARTY_BUILD_DIR}/zlib/lib/cmake/zlib")
-find_package(zlib CONFIG REQUIRED)
+set(ZLIB_DIR "${THIRDPARTY_BUILD_DIR}/zlib/lib/cmake/zlib")
+find_package(ZLIB CONFIG REQUIRED)
 
 # wallet-core
 set(TrustWalletCore_LIBRARY_DIR "${THIRDPARTY_BUILD_DIR}/wallet-core/lib")

--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -294,6 +294,9 @@ set(gnus_upnp_LIBRARY_DIR "${THIRDPARTY_BUILD_DIR}/gnus_upnp/lib")
 set(gnus_upnp_DIR "${THIRDPARTY_BUILD_DIR}/gnus_upnp/lib/cmake/gnus_upnp")
 find_package(gnus_upnp CONFIG REQUIRED)
 
+set(zlib_DIR "${THIRDPARTY_BUILD_DIR}/zlib/lib/cmake/zlib")
+find_package(zlib CONFIG REQUIRED)
+
 # wallet-core
 set(TrustWalletCore_LIBRARY_DIR "${THIRDPARTY_BUILD_DIR}/wallet-core/lib")
 set(TrustWalletCore_INCLUDE_DIR "${THIRDPARTY_BUILD_DIR}/wallet-core/include")

--- a/src/GeniusSDK.cpp
+++ b/src/GeniusSDK.cpp
@@ -113,11 +113,11 @@ namespace
             return outcome::failure( JsonError( std::string( "Failed to parse TokenID: " ) + tidRes.error().what() ) );
         }
 
-        strncpy( config_from_file.Addr, document["Address"].GetString(), document["Address"].GetStringLength() );
+        config_from_file.Addr             = std::string( document["Address"].GetString(), document["Address"].GetStringLength() );
         config_from_file.Cut              = document["Cut"].GetString();
         config_from_file.TokenValueInGNUS = document["TokenValue"].GetString();
         config_from_file.TokenID          = tidRes.value();
-        strncpy( config_from_file.BaseWritePath, base_path.data(), base_path.size() );
+        config_from_file.BaseWritePath    = base_path;
 
         return outcome::success( config_from_file );
     }


### PR DESCRIPTION
## Summary

Fix several macOS/Xcode build issues in GeniusSDK related to protobuf generation, target linking, and string handling.

## Changes

* Use `protobuf_host/bin/protoc` instead of `protobuf/bin/protoc` for host-side protobuf generation
* Update GeniusSDK targets to link directly against `sgns::sgns_genius_account`
* Remove the temporary compatibility alias workaround
* Replace `strncpy` usage with direct `std::string` assignment in `GeniusSDK.cpp`
* Update build submodule(cmaketemplate) to latest commit

These issues caused configure/build failures on macOS with newer Xcode / Clang toolchains and after recent target renaming changes in SuperGenius/develop.

* Verified clean configure + build locally on macOS
* Confirmed SuperGenius → GeniusSDK build flow completes successfully
* Tested with latest develop branches and updated build submodule
